### PR TITLE
update aus_livestock doc according to monthly source

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -242,20 +242,21 @@ NULL
 
 #' Australian livestock slaughter
 #'
-#' Meat production in Australia for human consumption from Q3 1965 to Q4 2018.
+#' Meat production in Australia for human consumption
 #'
-#' \code{aus_livestock} is an quarterly `tsibble` with one value:
+#' \code{aus_livestock} is a monthly `tsibble` with one value:
 #' \tabular{ll}{
 #'     Count:    \tab Number of animals slaughtered.\cr
 #' }
 #'
-#' Each series is uniquely identified by one key:
+#' Each series is uniquely identified using two keys:
 #' \tabular{ll}{
 #'     Animal:   \tab The animal slaughtered.\cr
+#'     State:    \tab The Australian state (or territory).\cr
 #' }
 #'
 #' @source
-#' Australian Bureau of Statistics, catalogue number 7218.0.55.001 tables 1 to 6.
+#' Australian Bureau of Statistics, catalogue number 7218.0.55.001 tables 1 to 7.
 #'
 #' @name aus_livestock
 #' @format Time series of class `tsibble`

--- a/man/aus_livestock.Rd
+++ b/man/aus_livestock.Rd
@@ -7,20 +7,21 @@
 Time series of class \code{tsibble}
 }
 \source{
-Australian Bureau of Statistics, catalogue number 7218.0.55.001 tables 1 to 6.
+Australian Bureau of Statistics, catalogue number 7218.0.55.001 tables 1 to 7.
 }
 \description{
-Meat production in Australia for human consumption from Q3 1965 to Q4 2018.
+Meat production in Australia for human consumption
 }
 \details{
-\code{aus_livestock} is an quarterly \code{tsibble} with one value:
+\code{aus_livestock} is a monthly \code{tsibble} with one value:
 \tabular{ll}{
 Count:    \tab Number of animals slaughtered.\cr
 }
 
-Each series is uniquely identified by one key:
+Each series is uniquely identified using two keys:
 \tabular{ll}{
 Animal:   \tab The animal slaughtered.\cr
+State:    \tab The Australian state (or territory).\cr
 }
 }
 \examples{


### PR DESCRIPTION
Hi,

updated the documentation of the `aus_livestock` data to reflect the change that it is from monthly source instead of quarterly (the change happened with [this commit](https://github.com/tidyverts/tsibbledata/commit/3c10bf8cf8d731038f945f9c4d647bf6b966c9ed))